### PR TITLE
feat: core networks for osnap

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -110,6 +110,14 @@ export default {
       ...sharedNetworkConfig,
       url: `https://linea-goerli.infura.io/v3/${INFURA_KEY}`,
     },
+    core: {
+      ...sharedNetworkConfig,
+      url: "https://rpc.coredao.org",
+    },
+    coreTestnet: {
+      ...sharedNetworkConfig,
+      url: "https://rpc.test.btcs.network",
+    },
   },
   namedAccounts: {
     deployer: 0,
@@ -119,5 +127,23 @@ export default {
   },
   etherscan: {
     apiKey: ETHERSCAN_API_KEY,
+    customChains: [
+      {
+        network: "coreTestnet",
+        chainId: 1115,
+        urls: {
+          apiURL: "https://api.test.btcs.network/api",
+          browserURL: "https://scan.test.btcs.network/",
+        },
+      },
+      {
+        network: "core",
+        chainId: 1116,
+        urls: {
+          apiURL: "https://openapi.coredao.org/api",
+          browserURL: "https://scan.coredao.org/",
+        },
+      },
+    ],
   },
 };

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -53,6 +53,7 @@ export enum SupportedNetworks {
   HardhatNetwork = 31337,
   LineaGoerli = 59140,
   Sepolia = 11155111,
+  CoreTestnet = 1115,
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {
@@ -215,6 +216,12 @@ export const ContractVersions: Record<
   },
   [SupportedNetworks.LineaGoerli]: CanonicalAddresses,
   [SupportedNetworks.Sepolia]: CanonicalAddresses,
+  [SupportedNetworks.CoreTestnet]: {
+    ...CanonicalAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]: {
+      "1.2.0": "0xD43463Fadd73373bE260b67F5825274F4403dAF0",
+    },
+  },
 };
 
 /** Addresses of the head versions of all contracts */

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -54,6 +54,7 @@ export enum SupportedNetworks {
   LineaGoerli = 59140,
   Sepolia = 11155111,
   CoreTestnet = 1115,
+  Core = 1116,
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {
@@ -220,6 +221,12 @@ export const ContractVersions: Record<
     ...CanonicalAddresses,
     [KnownContracts.OPTIMISTIC_GOVERNOR]: {
       "1.2.0": "0xD43463Fadd73373bE260b67F5825274F4403dAF0",
+    },
+  },
+  [SupportedNetworks.Core]: {
+    ...CanonicalAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]: {
+      "1.2.0": "0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa",
     },
   },
 };

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -53,8 +53,8 @@ export enum SupportedNetworks {
   HardhatNetwork = 31337,
   LineaGoerli = 59140,
   Sepolia = 11155111,
-  CoreTestnet = 1115,
-  Core = 1116,
+  CoreTestnet = 1115, // limited to UMA oSnap support (OPTIMISTIC_GOVERNOR)
+  Core = 1116, // // limited to UMA oSnap support (OPTIMISTIC_GOVERNOR)
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -53,8 +53,8 @@ export enum SupportedNetworks {
   HardhatNetwork = 31337,
   LineaGoerli = 59140,
   Sepolia = 11155111,
-  CoreTestnet = 1115, // limited to UMA oSnap support (OPTIMISTIC_GOVERNOR)
-  Core = 1116, // // limited to UMA oSnap support (OPTIMISTIC_GOVERNOR)
+  CoreTestnet = 1115,
+  Core = 1116,
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {

--- a/sdk/factory/mastercopyDeployer.ts
+++ b/sdk/factory/mastercopyDeployer.ts
@@ -106,7 +106,7 @@ export const deployMastercopyWithInitData = async (
   const initCodeHash = keccak256(initCode);
 
   const computedTargetAddress = getCreate2Address(
-    await singletonFactory.address(),
+    await singletonFactory.getAddress(),
     salt,
     initCodeHash
   );

--- a/sdk/factory/singletonFactory.ts
+++ b/sdk/factory/singletonFactory.ts
@@ -33,10 +33,12 @@ export const getSingletonFactory = async (
       "Singleton factory is not deployed on this chain. Deploying singleton factory..."
     );
     // fund the singleton factory deployer account
-    await signer.sendTransaction({
-      to: singletonDeployer,
-      value: parseEther("0.0247"),
-    });
+    await (
+      await signer.sendTransaction({
+        to: singletonDeployer,
+        value: parseEther("0.0247"),
+      })
+    ).wait();
 
     // deploy the singleton factory
     await (

--- a/tasks/deploy-replay.ts
+++ b/tasks/deploy-replay.ts
@@ -17,7 +17,7 @@ export const deploy = async (_: unknown, hre: HardhatRuntimeEnvironment) => {
   console.log(`\n\x1B[4m\x1B[1m${hre.network.name}\x1B[0m`);
 
   const [deployer] = await hre.ethers.getSigners();
-  const signer = hre.ethers.provider.getSigner(deployer.address);
+  const signer = await hre.ethers.provider.getSigner(deployer.address);
   for (let index = 0; index < contracts.length; index++) {
     const initData: InitData | undefined = MasterCopyInitData[contracts[index]];
 

--- a/tasks/singleton-deployment.ts
+++ b/tasks/singleton-deployment.ts
@@ -16,7 +16,7 @@ export const deploy = async (_: unknown, hre: HardhatRuntimeEnvironment) => {
   }
 
   const [deployer] = await hre.ethers.getSigners();
-  await deployModuleFactory(hre.ethers.provider.getSigner(deployer.address));
+  await deployModuleFactory(await hre.ethers.provider.getSigner(deployer.address));
 };
 
 task(


### PR DESCRIPTION
## Add a feature

### Feature Request

Add support of UMA oSnap modules on Core networks (https://coredao.org/)

### Implementation

Add support by deploying module proxy factory and oSnap module mastercopy on Core mainnet/testnet

### Additional Context

Also added hardhat config and ran `deploy` scripts:

```
coreTestnet
    realityETH
  ✔ Mastercopy deployed to:        0x4e35DA39Fa5893a70A40Ce964F993d891E607cC0 🎉 
    realityERC20
  ✔ Mastercopy deployed to:        0x7276813b21623d89BA8984B225d5792943DD7dbF 🎉 
    bridge
  ✔ Mastercopy deployed to:        0x03B5eBD2CB2e3339E93774A1Eb7c8634B8C393A9 🎉 
    delay
  ✔ Mastercopy deployed to:        0xd54895B1121A2eE3f37b502F507631FA1331BED6 🎉 
    exit
  ✔ Mastercopy deployed to:        0x3ed380a282aDfA3460da28560ebEB2F6D967C9f5 🎉 
    exitERC721
  ✔ Mastercopy deployed to:        0xE0eCE32Eb4BE4E9224dcec6a4FcB335c1fe05CDe 🎉 
    circulatingSupplyERC20
  ✔ Mastercopy deployed to:        0x5Ed57C291a184cc244F5c9B5E9F11a8DD08BBd12 🎉 
    circulatingSupplyERC721
  ✔ Mastercopy deployed to:        0xBD34D00dC0ae37C687F784A11FA6a0F2c5726Ba3 🎉 
    scopeGuard
  ✔ Mastercopy deployed to:        0xeF27fcd3965a866b22Fb2d7C689De9AB7e611f1F 🎉 
    factory
  ✔ Mastercopy already deployed to: 0x000000000000aDdB49795b0f9bA5BC298cDda236
    roles
  ✔ Mastercopy deployed to:        0xD8DfC1d938D7D163C5231688341e9635E9011889 🎉 
    roles_v1
  ✔ Mastercopy already deployed to: 0xD8DfC1d938D7D163C5231688341e9635E9011889
    roles_v2
  ✔ Mastercopy already deployed to: 0x9646fDAD06d3e24444381f44362a3B0eB343D337
    ozGovernor
  ✔ Mastercopy deployed to:        0xe28c39FAC73cce2B33C4C003049e2F3AE43f77d5 🎉 
    erc20Votes
  ✔ Mastercopy deployed to:        0x752c61de75ADA0F8a33e048d2F773f51172f033e 🎉 
    erc721Votes
  ✔ Mastercopy deployed to:        0xeFf38b2eBB95ACBA09761246045743f40e762568 🎉 
    multisendEncoder
  ✔ Mastercopy deployed to:        0xb67EDe523171325345780fA3016b7F5221293df0 🎉 
    permissions
  ✔ Mastercopy deployed to:        0x33D1C5A5B6a7f3885c7467e829aaa21698937597 🎉 
    connext
  ✔ Mastercopy deployed to:        0x7dE07b9De0bf0FABf31A188DE1527034b2aF36dB 🎉 
```
and
```
core
    realityETH
  ✔ Mastercopy deployed to:        0x4e35DA39Fa5893a70A40Ce964F993d891E607cC0 🎉 
    realityERC20
  ✔ Mastercopy deployed to:        0x7276813b21623d89BA8984B225d5792943DD7dbF 🎉 
    bridge
  ✔ Mastercopy deployed to:        0x03B5eBD2CB2e3339E93774A1Eb7c8634B8C393A9 🎉 
    delay
  ✔ Mastercopy deployed to:        0xd54895B1121A2eE3f37b502F507631FA1331BED6 🎉 
    exit
  ✔ Mastercopy deployed to:        0x3ed380a282aDfA3460da28560ebEB2F6D967C9f5 🎉 
    exitERC721
  ✔ Mastercopy deployed to:        0xE0eCE32Eb4BE4E9224dcec6a4FcB335c1fe05CDe 🎉 
    circulatingSupplyERC20
  ✔ Mastercopy deployed to:        0x5Ed57C291a184cc244F5c9B5E9F11a8DD08BBd12 🎉 
    circulatingSupplyERC721
  ✔ Mastercopy deployed to:        0xBD34D00dC0ae37C687F784A11FA6a0F2c5726Ba3 🎉 
    scopeGuard
  ✔ Mastercopy deployed to:        0xeF27fcd3965a866b22Fb2d7C689De9AB7e611f1F 🎉 
    factory
  ✔ Mastercopy already deployed to: 0x000000000000aDdB49795b0f9bA5BC298cDda236
    roles
  ✔ Mastercopy deployed to:        0xD8DfC1d938D7D163C5231688341e9635E9011889 🎉 
    roles_v1
  ✔ Mastercopy already deployed to: 0xD8DfC1d938D7D163C5231688341e9635E9011889
    roles_v2
  ✔ Mastercopy already deployed to: 0x9646fDAD06d3e24444381f44362a3B0eB343D337
    ozGovernor
  ✔ Mastercopy deployed to:        0xe28c39FAC73cce2B33C4C003049e2F3AE43f77d5 🎉 
    erc20Votes
  ✔ Mastercopy deployed to:        0x752c61de75ADA0F8a33e048d2F773f51172f033e 🎉 
    erc721Votes
  ✔ Mastercopy deployed to:        0xeFf38b2eBB95ACBA09761246045743f40e762568 🎉 
    multisendEncoder
  ✔ Mastercopy deployed to:        0xb67EDe523171325345780fA3016b7F5221293df0 🎉 
    permissions
  ✔ Mastercopy deployed to:        0x33D1C5A5B6a7f3885c7467e829aaa21698937597 🎉 
    connext
  ✔ Mastercopy deployed to:        0x7dE07b9De0bf0FABf31A188DE1527034b2aF36dB 🎉 
```

This PR also fixes couple of syntax errors so that above deployment tasks can be performed
